### PR TITLE
Assign dictionary item to ErrorMessage

### DIFF
--- a/Umbraco Validation Attributes/UmbracoValidationAttributes/UmbracoRegexValidation.cs
+++ b/Umbraco Validation Attributes/UmbracoValidationAttributes/UmbracoRegexValidation.cs
@@ -17,7 +17,7 @@ namespace UmbracoValidationAttributes
 
         public IEnumerable<ModelClientValidationRule> GetClientValidationRules(ModelMetadata metadata, ControllerContext context)
         {
-            UmbracoValidationHelper.GetDictionaryItem(_errorMessageDictionaryKey);
+            ErrorMessage = UmbracoValidationHelper.GetDictionaryItem(_errorMessageDictionaryKey);
 
             var error           = FormatErrorMessage(metadata.DisplayName);
             var rule            = new ModelClientValidationRule();


### PR DESCRIPTION
Just noticed that the error message assigned to a dictionary item wasn't being returned for Regex Validator. Seemed to be missing assigning the dictionary item to the ErrorMessage property.